### PR TITLE
Altered playlist response structure

### DIFF
--- a/musicmirror/src/App.js
+++ b/musicmirror/src/App.js
@@ -9,7 +9,8 @@ function App() {
   const [list, setList] = useState();
   
   const handleMsg = async (data) => {
-    setList(await findSongs(data));
+    //change search result count (5) to a user input value later
+    setList(await findSongs(data, 5));
   }
 
   return (

--- a/musicmirror/src/playlist.js
+++ b/musicmirror/src/playlist.js
@@ -1,4 +1,4 @@
-export async function findSongs(input){
+export async function findSongs(input, resCount){
     console.log(input);
     const token = localStorage.getItem("token");
     //separate each query by line
@@ -7,7 +7,6 @@ export async function findSongs(input){
     let playlist = {
         title: "Music Mirror Playlist",
         songs: [],
-        uris: []
     };
     let url = "";
     for(let i in search){
@@ -22,32 +21,39 @@ export async function findSongs(input){
         });
         let obj = await resp.json();
         //if exists, add to playlist
-        if(Object.keys(obj.tracks.items).length > 0){
-            playlist.uris.push(obj.tracks.items[0].uri);
+        let results = {
+            query: "",
+            tracks: [],
+        }
+
+        let res = 0;
+        while(res < resCount && res < Object.keys(obj.tracks.items).length) {
             let names = "";
-            for(let i in obj.tracks.items[0].artists){
-                names += obj.tracks.items[0].artists[i].name + ", ";
+            for(let j in obj.tracks.items[res].artists){
+                names += obj.tracks.items[res].artists[j].name + ", ";
             }
             names = names.substring(0, names.length - 2)
-            let time = new Date(obj.tracks.items[0].duration_ms);
-            //console.log(`duration: ${duration}`);
-            let song = {
-                title: obj.tracks.items[0].name,
+
+            let time = new Date(obj.tracks.items[res].duration_ms);
+            let track = {
+                title: obj.tracks.items[res].name,
                 artist: names,
-                album: obj.tracks.items[0].album.name,
+                album: obj.tracks.items[res].album.name,
                 length: `${time.getMinutes()}:${time.getSeconds()}`,
-                query: search[i],
+                uri: obj.tracks.items[res].uri,
             };
-            playlist.songs.push(song);
+            results.tracks.push(track);
+            console.log(track);
+            res++;
         }
+        results.query = search[i];
+        playlist.songs.push(results);
     }
     console.log(playlist);
     return playlist;
 }
 
 export async function genPlaylist(list){
-    console.log("in gen");
-    console.log(list);
     const user_id = localStorage.getItem("user_id");
     const token = localStorage.getItem("token");
     // if list size > 0, create playlist (api req)


### PR DESCRIPTION
In order to handle carousel functionality multiple results per song have been added to the playlist structure.
There is a new argument into findSongs() called resCount that determines how many of these results will be kept in the structure, this should become a user defined value later but is fixed at 5 for now.
The new structure is outlined below:
### playlist:
- Title
- songs (array):
    - results:
        - query
        - tracks (array):
            - title
            - artist
            - album
            - length
            - uri